### PR TITLE
router: fixed nftables boot issue 

### DIFF
--- a/nixos/hosts/router/default.nix
+++ b/nixos/hosts/router/default.nix
@@ -101,6 +101,7 @@ in {
       inherit addresses;
       inherit interfaces;
       inherit lib;
+      inherit pkgs;
       inherit secrets;
     })
     ../../minimal.nix

--- a/nixos/hosts/router/routing.nix
+++ b/nixos/hosts/router/routing.nix
@@ -13,7 +13,7 @@
 
         table netdev filter {
           chain ingress {
-            type filter hook ingress devices = { ${interfaces.wan.name}, ${interfaces.lan.name}, ${interfaces.vpn.name} } priority -500;
+            type filter hook ingress devices = { ${interfaces.wan.name}, ${interfaces.lan.name} } priority -500;
 
             # block weird packets
             tcp flags & (fin|syn) == (fin|syn) drop
@@ -41,9 +41,6 @@
             ip6 nexthdr icmpv6 limit rate 5/second accept
             ip6 nexthdr icmpv6 counter drop
 
-            # accept incoming vpn connections
-            udp dport ${builtins.toString addresses.vpn.port} accept
-
             # drop incoming packets that are not locally addressed
             fib daddr . iif type != local drop
           }
@@ -54,14 +51,9 @@
             # accept all icmp requests -- TODO this could be constrained or even rate-limited
             ip protocol icmp accept
             ip6 nexthdr icmpv6 accept
-            udp dport ${builtins.toString addresses.vpn.port} accept
           }
           chain inbound_lan {
             # accept all LAN traffic--yolo!
-            accept
-          }
-          chain inbound_vpn {
-            # accept all vpn traffic--yolo!
             accept
           }
           chain inbound {
@@ -75,7 +67,7 @@
 
             ct state vmap { established : accept, related : accept, invalid: drop }
 
-            iifname vmap { lo : accept, ${interfaces.wan.name} : jump inbound_wan, ${interfaces.lan.name} : jump inbound_lan, ${interfaces.vpn.name} : jump inbound_vpn }
+            iifname vmap { lo : accept, ${interfaces.wan.name} : jump inbound_wan, ${interfaces.lan.name} : jump inbound_lan }
           }
           chain forward {
             type filter hook forward priority 0; policy drop;
@@ -90,9 +82,6 @@
 
             # always forward lan traffic anywhere
             iifname ${interfaces.lan.name} accept
-
-            # only allow vpn to be forwarded to lan and lo-- i dont use my home vpn as anything but a bridge to home network
-            iifname ${interfaces.vpn.name} oifname { ${interfaces.lan.name}, lo } accept
           }
           chain postrouting {
             type nat hook postrouting priority 100; policy accept;

--- a/nixos/hosts/router/wireguard.nix
+++ b/nixos/hosts/router/wireguard.nix
@@ -3,10 +3,38 @@
   interfaces,
   secrets,
   lib,
+  pkgs,
   ...
-}: {
+}: let
+  nft = pkgs.nftables;
+in {
   networking.wireguard.interfaces = {
     "${interfaces.vpn.name}" = {
+      postSetup = ''
+        # modify ingress chain filter to include wg0 device
+        ${nft}/bin/nft chain netdev filter ingress '{ type filter hook ingress devices = { ${interfaces.wan.name}, ${interfaces.lan.name}, ${interfaces.vpn.name} } priority -500; policy accept; }'
+
+        # insert accept dport rule 2nd to last in ingress_wan chain in filter table
+          # use handles as in `nft --handle list ruleset`
+        ${nft}/bin/nft add rule netdev filter ingress_wan handle 16 udp dport ${builtins.toString addresses.vpn.port} accept
+
+        # append accept dport rule to inbound_wan chain in global table
+        ${nft}/bin/nft add rule inet global inbound_wan udp dport ${builtins.toString addresses.vpn.port} accept
+
+        # append jump accept iifname vpn to inbound chain in global table
+        ${nft}/bin/nft add chain inet global inbound_vpn
+        ${nft}/bin/nft add rule inet global inbound_vpn accept
+        ${nft}/bin/nft add rule inet global inbound iifname ${interfaces.vpn.name} jump inbound_vpn
+
+        # append accept iifname vpn oifname { lan, lo } rule to forward chain in global table
+        ${nft}/bin/nft add rule inet global forward iifname ${interfaces.vpn.name} oifname { ${interfaces.lan.name}, lo } accept
+      '';
+      postShutdown = ''
+        # inverse of postSetup -- remove all rules added AND NOTHING MORE
+        # could do nothing... or just restart nftables service...?
+        systemctl restart nftables
+      '';
+
       ips = ["${addresses.vpn.ipv4.addr}/24" "${addresses.vpn.ipv6.addr}/64"];
       listenPort = addresses.vpn.port;
       privateKeyFile = "/home/andreweggleston/.wireguard-keys/private";


### PR DESCRIPTION
When the router boots up, the nftables service starts before the wireguard interface is up.
This is an issue because the nftables ruleset depends on the wg0 interface existing. When nftables tried to start with a missing interface, it would error on "device not found" and abort.
A temp fix was just remoting into the router and manually restarting nftables--but this isn't optimal.
The right idea is to use the wireguard service's "postSetup" and "postShutdown" attributes to add the vpn-related chains/rules using the `nft` command.
When the interface goes down, we can just restart the nftables service to revert the ruleset.

This pull request moves vpn-related rules out of the nftables ruleset and into the wireguard interface's "postSetup" and "postShutdown" attributes.